### PR TITLE
Introduce notifier interface

### DIFF
--- a/src/main/java/com/example/smartnotifier/service/NotificationService.java
+++ b/src/main/java/com/example/smartnotifier/service/NotificationService.java
@@ -6,86 +6,21 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import com.example.smartnotifier.model.Event;
-import com.example.smartnotifier.service.format.EmailFormatter;
-import com.example.smartnotifier.service.format.EmailFormatter.EmailMessage;
-import com.example.smartnotifier.service.format.PushFormatter;
-import com.example.smartnotifier.service.format.PushFormatter.PushMessage;
-import com.example.smartnotifier.service.format.SlackFormatter;
-import com.example.smartnotifier.service.format.SmsFormatter;
-import com.example.smartnotifier.service.logging.NotificationLogger;
-import com.example.smartnotifier.service.retry.RetryHandler;
-import com.example.smartnotifier.service.retry.RetryHandler.RetriableTask;
-import com.example.smartnotifier.service.send.EmailSender;
-import com.example.smartnotifier.service.send.PushSender;
-import com.example.smartnotifier.service.send.SlackSender;
-import com.example.smartnotifier.service.send.SmsSender;
+import com.example.smartnotifier.service.dispatch.ChannelDispatcher;
 
 @Service
 public class NotificationService {
 
-	private final EmailFormatter emailFormatter;
-	private final SmsFormatter smsFormatter;
-	private final PushFormatter pushFormatter;
-	private final SlackFormatter slackFormatter;
-	private final EmailSender emailSender;
-	private final SmsSender smsSender;
-	private final PushSender pushSender;
-	private final SlackSender slackSender;
-	private final NotificationLogger logger;
-	private final RetryHandler retryHandler;
+        private final ChannelDispatcher dispatcher;
 
-	@Autowired
-	public NotificationService(EmailFormatter emailFormatter, SmsFormatter smsFormatter, PushFormatter pushFormatter,
-			SlackFormatter slackFormatter, EmailSender emailSender, SmsSender smsSender, PushSender pushSender,
-			SlackSender slackSender, NotificationLogger logger, RetryHandler retryHandler) {
-		this.emailFormatter = emailFormatter;
-		this.smsFormatter = smsFormatter;
-		this.pushFormatter = pushFormatter;
-		this.slackFormatter = slackFormatter;
-		this.emailSender = emailSender;
-		this.smsSender = smsSender;
-		this.pushSender = pushSender;
-		this.slackSender = slackSender;
-		this.logger = logger;
-		this.retryHandler = retryHandler;
-	}
+        @Autowired
+        public NotificationService(ChannelDispatcher dispatcher) {
+                this.dispatcher = dispatcher;
+        }
 
 	public void sendAllNotifications(Event event, List<String> channels) {
-		for (String channel : channels) {
-			try {
-				switch (channel) {
-				case "EMAIL":
-					EmailMessage email = emailFormatter.format(event);
-					int attempts = retryHandler.execute(new RetriableTask() {
-						@Override
-						public void run() throws Exception {
-							emailSender.send(event.getRecipientEmail(), email);
-						}
-					}, 3);
-					logger.success(channel, event, attempts);
-					break;
-				case "SMS":
-					String smsMessage = smsFormatter.format(event);
-					smsSender.send(event.getRecipientPhone(), smsMessage);
-					logger.success(channel, event, 1);
-					break;
-				case "PUSH":
-					PushMessage pushMessage = pushFormatter.format(event);
-					pushSender.send(event.getDeviceToken(), pushMessage);
-					logger.success(channel, event, 1);
-					break;
-				case "SLACK":
-					String slackMessage = slackFormatter.format(event);
-					slackSender.send(event.getSlackChannelId(), slackMessage);
-					logger.success(channel, event, 1);
-					break;
-				default:
-					System.err.println("Unknown channel: " + channel);
-					break;
-				}
-			} catch (Exception e) {
-				logger.error(channel, e, 1);
-			}
-		}
+                for (String channel : channels) {
+                        dispatcher.dispatch(event, channel);
+                }
 	}
 }

--- a/src/main/java/com/example/smartnotifier/service/dispatch/ChannelDispatcher.java
+++ b/src/main/java/com/example/smartnotifier/service/dispatch/ChannelDispatcher.java
@@ -1,0 +1,33 @@
+package com.example.smartnotifier.service.dispatch;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import com.example.smartnotifier.model.Event;
+
+@Component
+public class ChannelDispatcher {
+
+    private final Map<String, Notifier> notifierMap;
+
+    @Autowired
+    public ChannelDispatcher(List<Notifier> notifiers) {
+        // Spring injects all beans that implement the Notifier interface
+        // which allows adding new channels without modifying this class
+        this.notifierMap = notifiers.stream()
+                .collect(Collectors.toMap(Notifier::getChannel, n -> n));
+    }
+
+    public void dispatch(Event event, String channel) {
+        Notifier notifier = notifierMap.get(channel);
+        if (notifier != null) {
+            notifier.notify(event);
+        } else {
+            System.err.println("Unknown channel: " + channel);
+        }
+    }
+}

--- a/src/main/java/com/example/smartnotifier/service/dispatch/EmailNotifier.java
+++ b/src/main/java/com/example/smartnotifier/service/dispatch/EmailNotifier.java
@@ -1,0 +1,49 @@
+package com.example.smartnotifier.service.dispatch;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import com.example.smartnotifier.model.Event;
+import com.example.smartnotifier.service.format.EmailFormatter;
+import com.example.smartnotifier.service.format.EmailFormatter.EmailMessage;
+import com.example.smartnotifier.service.logging.NotificationLogger;
+import com.example.smartnotifier.service.retry.RetryHandler;
+import com.example.smartnotifier.service.send.EmailSender;
+
+@Component
+public class EmailNotifier implements Notifier {
+    private final EmailFormatter formatter;
+    private final EmailSender sender;
+    private final NotificationLogger logger;
+    private final RetryHandler retryHandler;
+
+    @Autowired
+    public EmailNotifier(EmailFormatter formatter, EmailSender sender,
+                         NotificationLogger logger, RetryHandler retryHandler) {
+        this.formatter = formatter;
+        this.sender = sender;
+        this.logger = logger;
+        this.retryHandler = retryHandler;
+    }
+
+    @Override
+    public String getChannel() {
+        return "EMAIL";
+    }
+
+    @Override
+    public void notify(Event event) {
+        try {
+            EmailMessage email = formatter.format(event);
+            int attempts = retryHandler.execute(new RetryHandler.RetriableTask() {
+                @Override
+                public void run() throws Exception {
+                    sender.send(event.getRecipientEmail(), email);
+                }
+            }, 3); // RetriableTask is a functional interface, so a lambda could be used here
+            logger.success(getChannel(), event, attempts);
+        } catch (Exception e) {
+            logger.error(getChannel(), e, 1);
+        }
+    }
+}

--- a/src/main/java/com/example/smartnotifier/service/dispatch/Notifier.java
+++ b/src/main/java/com/example/smartnotifier/service/dispatch/Notifier.java
@@ -1,0 +1,8 @@
+package com.example.smartnotifier.service.dispatch;
+
+import com.example.smartnotifier.model.Event;
+
+public interface Notifier {
+    String getChannel();
+    void notify(Event event);
+}

--- a/src/main/java/com/example/smartnotifier/service/dispatch/PushNotifier.java
+++ b/src/main/java/com/example/smartnotifier/service/dispatch/PushNotifier.java
@@ -1,0 +1,40 @@
+package com.example.smartnotifier.service.dispatch;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import com.example.smartnotifier.model.Event;
+import com.example.smartnotifier.service.format.PushFormatter;
+import com.example.smartnotifier.service.format.PushFormatter.PushMessage;
+import com.example.smartnotifier.service.logging.NotificationLogger;
+import com.example.smartnotifier.service.send.PushSender;
+
+@Component
+public class PushNotifier implements Notifier {
+    private final PushFormatter formatter;
+    private final PushSender sender;
+    private final NotificationLogger logger;
+
+    @Autowired
+    public PushNotifier(PushFormatter formatter, PushSender sender, NotificationLogger logger) {
+        this.formatter = formatter;
+        this.sender = sender;
+        this.logger = logger;
+    }
+
+    @Override
+    public String getChannel() {
+        return "PUSH";
+    }
+
+    @Override
+    public void notify(Event event) {
+        try {
+            PushMessage message = formatter.format(event);
+            sender.send(event.getDeviceToken(), message);
+            logger.success(getChannel(), event, 1);
+        } catch (Exception e) {
+            logger.error(getChannel(), e, 1);
+        }
+    }
+}

--- a/src/main/java/com/example/smartnotifier/service/dispatch/SlackNotifier.java
+++ b/src/main/java/com/example/smartnotifier/service/dispatch/SlackNotifier.java
@@ -1,0 +1,39 @@
+package com.example.smartnotifier.service.dispatch;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import com.example.smartnotifier.model.Event;
+import com.example.smartnotifier.service.format.SlackFormatter;
+import com.example.smartnotifier.service.logging.NotificationLogger;
+import com.example.smartnotifier.service.send.SlackSender;
+
+@Component
+public class SlackNotifier implements Notifier {
+    private final SlackFormatter formatter;
+    private final SlackSender sender;
+    private final NotificationLogger logger;
+
+    @Autowired
+    public SlackNotifier(SlackFormatter formatter, SlackSender sender, NotificationLogger logger) {
+        this.formatter = formatter;
+        this.sender = sender;
+        this.logger = logger;
+    }
+
+    @Override
+    public String getChannel() {
+        return "SLACK";
+    }
+
+    @Override
+    public void notify(Event event) {
+        try {
+            String message = formatter.format(event);
+            sender.send(event.getSlackChannelId(), message);
+            logger.success(getChannel(), event, 1);
+        } catch (Exception e) {
+            logger.error(getChannel(), e, 1);
+        }
+    }
+}

--- a/src/main/java/com/example/smartnotifier/service/dispatch/SmsNotifier.java
+++ b/src/main/java/com/example/smartnotifier/service/dispatch/SmsNotifier.java
@@ -1,0 +1,39 @@
+package com.example.smartnotifier.service.dispatch;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import com.example.smartnotifier.model.Event;
+import com.example.smartnotifier.service.format.SmsFormatter;
+import com.example.smartnotifier.service.logging.NotificationLogger;
+import com.example.smartnotifier.service.send.SmsSender;
+
+@Component
+public class SmsNotifier implements Notifier {
+    private final SmsFormatter formatter;
+    private final SmsSender sender;
+    private final NotificationLogger logger;
+
+    @Autowired
+    public SmsNotifier(SmsFormatter formatter, SmsSender sender, NotificationLogger logger) {
+        this.formatter = formatter;
+        this.sender = sender;
+        this.logger = logger;
+    }
+
+    @Override
+    public String getChannel() {
+        return "SMS";
+    }
+
+    @Override
+    public void notify(Event event) {
+        try {
+            String message = formatter.format(event);
+            sender.send(event.getRecipientPhone(), message);
+            logger.success(getChannel(), event, 1);
+        } catch (Exception e) {
+            logger.error(getChannel(), e, 1);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement `Notifier` interface and per-channel notifier classes
- refactor `ChannelDispatcher` to delegate to `Notifier` implementations
- clarify injection behavior in `ChannelDispatcher`
- use explicit `RetriableTask` class in `EmailNotifier`

## Testing
- `./gradlew build` *(fails: Unable to tunnel through proxy)*
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_686c38508b348321ab1d881e9a249242